### PR TITLE
Remove fixed width on the search widget container

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -46,7 +46,7 @@ export class App extends Component {
 
     return (
       <div className="__sw-container__" style={styles.container}>
-        <div className="container">
+        <div className="container" style={{width: '100%'}}>
           <Form />
           {
             result &&

--- a/src/stylesheets/form.js
+++ b/src/stylesheets/form.js
@@ -19,7 +19,7 @@ const form = {
     fontWeight: 300,
     lineHeight: '28px',
     padding: '8px 10px',
-    width: '540px'
+    width: '100%'
   },
 
   inputWrapper: {

--- a/src/stylesheets/styles.js
+++ b/src/stylesheets/styles.js
@@ -16,7 +16,7 @@ const styles = {
 
   container: {
     padding: '20px',
-    width: '600px'
+    width: '100%'
   },
 
   img: {


### PR DESCRIPTION
### Background

Previously, the width of the search widget is fixed to 600px. This is not suitable for users who wish to adjust the size of the widget.

### Implementation

Set width to 100%. User can now set a fixed width at the container that loads the search widget.