### PR TITLE
[Bug] Uncaught Type error e when user perform search

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -44,7 +44,7 @@ export class Form extends Component {
     } = this.props;
 
     return (
-      <form className="__sw-input__" style={styles.form.container} onSubmit={e => e.preventDefault()}>
+      <form className="__sw-input__" style={styles.form.container}>
         <div style={styles.form.inputWrapper}>
           <Input
             name="keyword"


### PR DESCRIPTION
### Users cannot perform search using embedded search widget
This is due to an uncaught type error ```e``` when user key in keywords in the search bar. Removing ```e.preventDefault``` in the standalone search widget fixes the issue.