### PR TITLE
[Bug Fix] Prevent form from submission when user press enter

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -40,11 +40,12 @@ export class Form extends Component {
     const {
       filters,
       isFetching,
+      handleSubmit,
       submitHandler
     } = this.props;
 
     return (
-      <form className="__sw-input__" style={styles.form.container}>
+      <form className="__sw-input__" style={styles.form.container} onSubmit={handleSubmit}>
         <div style={styles.form.inputWrapper}>
           <Input
             name="keyword"
@@ -103,6 +104,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 Form.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
   isFetching: PropTypes.bool.isRequired,
   submitHandler: PropTypes.func.isRequired,
   filters: PropTypes.shape({}).isRequired

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -51,10 +51,11 @@ export class App extends Component {
 
     return (
       <div className="__sw-container__" style={styles.container}>
-        <div className="container" style={{width: '100%'}}>
+        <div className="container" style={{ width: '100%' }}>
           <Form
             isFetching={isFetching}
             filters={filters}
+            onSubmit={() => {}}
           />
           {
             result &&


### PR DESCRIPTION
Form will be refreshed if users press enter. This is not desirable because the search should be performed while users are typing.
Refer to https://github.com/erikras/redux-form/issues/1270, handleSubmit supposes to do e.preventDefault() to preview form from submitting.
Also, refer to https://github.com/erikras/redux-form/issues/190, we need to pass onSubmit as props to the form